### PR TITLE
branch4

### DIFF
--- a/.github/workflows/02-manual-trigger-job.yml
+++ b/.github/workflows/02-manual-trigger-job.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install az ml extension
       run: az extension add -n ml -y
     - name: Azure login
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         creds: ${{secrets.AZURE_CREDENTIALS}}
     - name: Trigger model training


### PR DESCRIPTION
adjust to
- name: Azure login
      uses: azure/login@v2
in 02-manual-trigger-job.yml because of github update. job completed with error with azure/login@v1